### PR TITLE
Apply short hostname instead of FQDN

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for hostname
 - name: update the hostname - hostname module
   hostname:
-    name: "{{ inventory_hostname }}"
+    name: "{{ inventory_hostname_short }}"
   tags: [configuration, hostname]
 
 - name: update the hostname - /etc/hostname file


### PR DESCRIPTION
Hostname (instead of FQDN) should not only be written to /etc/hostname, but also applied in hostname command