### PR TITLE
Add feature bind FQDN and shortname custom ip address.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you just name it with the hostname in the inventory, it will similarly work (
 
 * `hostname_hostname`: [default: `"{{ inventory_hostname }}"`]: FQDN
 * `hostname_hostname_short`: [default: `"{{ inventory_hostname_short }}"`]: Hostname
-* `hostname_use_full`: [default: `false`]: If set to `true` `hostname` equal `FQDN`
+* `hostname_hostname_use_full`: [default: `false`]: If set to `true` `hostname` equal `FQDN`
 * `hostname_hostname_ip_address`: [default: `127.0.1.1`]: `FQDN` and `shortname` resolve to `hostname_hostname_ip_address`
 * `hostname_additional_hosts`: [default: `[]`]: Hosts declaration
 * `hostname_additional_hosts.{n}.ip_address`: [required]: IP address

--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ If you just name it with the hostname in the inventory, it will similarly work (
 
 * `hostname_hostname`: [default: `"{{ inventory_hostname }}"`]: FQDN
 * `hostname_hostname_short`: [default: `"{{ inventory_hostname_short }}"`]: Hostname
+* `hostname_use_full`: [default: `false`]: If set to `true` `hostname` equal `FQDN`
+* `hostname_hostname_ip_address`: [default: `127.0.1.1`]: `FQDN` and `shortname` resolve to `hostname_hostname_ip_address`
 * `hostname_additional_hosts`: [default: `[]`]: Hosts declaration
 * `hostname_additional_hosts.{n}.ip_address`: [required]: IP address
 * `hostname_additional_hosts.{n}.hostname`: [required]: FQDN
 * `hostname_additional_hosts.{n}.hostname_short`: [required]: Hostname
-* `hostname_use_full`: [default: `false`]: If set to `true` `hostname` equal `FQDN`
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,5 +3,5 @@
 hostname_hostname: "{{ inventory_hostname }}"
 hostname_hostname_short: "{{ inventory_hostname_short }}"
 hostname_additional_hosts: []
-hostname_use_full: false
+hostname_hostname_use_full: false
 hostname_hostname_ip_address: '127.0.1.1'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@ hostname_hostname: "{{ inventory_hostname }}"
 hostname_hostname_short: "{{ inventory_hostname_short }}"
 hostname_additional_hosts: []
 hostname_use_full: false
+hostname_hostname_ip_address: '127.0.1.1'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 ---
 - name: update the hostname - hostname module
   hostname:
-    name: "{{ hostname_hostname if hostname_use_full else hostname_hostname_short }}"
+    name: "{{ hostname_hostname if hostname_hostname_use_full else hostname_hostname_short }}"
   tags:
     - configuration
     - hostname

--- a/templates/etc/hostname.j2
+++ b/templates/etc/hostname.j2
@@ -1,1 +1,1 @@
-{{ hostname_hostname if hostname_use_full else hostname_hostname_short }}
+{{ hostname_hostname if hostname_hostname_use_full else hostname_hostname_short }}

--- a/templates/etc/hosts.j2
+++ b/templates/etc/hosts.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 127.0.0.1 localhost.localdomain localhost
-127.0.1.1 {{ hostname_hostname }} {{ hostname_hostname_short }}
+{{ hostname_hostname_ip_address }} {{ hostname_hostname }} {{ hostname_hostname_short }}
 
 # The following lines are desirable for IPv6 capable hosts
 ::1 ip6-localhost ip6-loopback


### PR DESCRIPTION
For example:
```
---
hostname_ip_address: '{{ ansible_default_ipv4.address }}'
```
Result:
```
# cat /etc/hosts
# Ansible managed

127.0.0.1 localhost.localdomain localhost
default_route_ip fqdn shortname

# The following lines are desirable for IPv6 capable hosts
::1 ip6-localhost ip6-loopback
fe00::0 ip6-localnet
ff00::0 ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
ff02::3 ip6-allhosts
```