### PR TITLE
Make sure dbus is present before updating hostname

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,10 @@
 # tasks file for hostname
 ---
+- name: make sure dbus is present
+  apt:
+    name: dbus
+    state: present
+
 - name: update the hostname - hostname module
   hostname:
     name: "{{ hostname_hostname if hostname_hostname_use_full else hostname_hostname_short }}"


### PR DESCRIPTION
On systems where dbus is not installed prior the execution of this role
the following error is shown:

```
  TASK [Oefenweb.hostname : update the hostname - hostname module]
  fatal: [example.com]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python3.7"}, "changed": false, "msg": "Command failed rc=1, out=, err=Failed to create bus connection: No such file or directory\n"}
```

Closes: Oefenweb/ansible-hostname#12